### PR TITLE
Set speedj_time from the parameter server

### DIFF
--- a/src/ur_realtime_communication.cpp
+++ b/src/ur_realtime_communication.cpp
@@ -98,10 +98,17 @@ void UrRealtimeCommunication::addCommandToQueue(std::string inp) {
 void UrRealtimeCommunication::setSpeed(double q0, double q1, double q2,
 		double q3, double q4, double q5, double acc) {
 	char cmd[1024];
+	
 	if( robot_state_->getVersion() >= 3.3 ) {
+		double speedj_time = 0.008;
+		if (ros::param::get("~speedj_time", speedj_time)) {
+			if (speedj_time < 0.008) {
+				speedj_time = 0.008;
+			}
+		}
 		sprintf(cmd,
-				"speedj([%1.5f, %1.5f, %1.5f, %1.5f, %1.5f, %1.5f], %f, 0.008)\n",
-				q0, q1, q2, q3, q4, q5, acc);
+				"speedj([%1.5f, %1.5f, %1.5f, %1.5f, %1.5f, %1.5f], %f, %f)\n",
+				q0, q1, q2, q3, q4, q5, acc, speedj_time);
 	}
 	else if( robot_state_->getVersion() >= 3.1 ) {
 		sprintf(cmd,


### PR DESCRIPTION
When using the velocity-based controller, we were experiencing stuttering/jerky movements on our UR3.  After some investigating, I determined that this behavior was caused by the time parameter in the speedj() command, which was set too low for our setup (UR3 v.3.5, Kinetic, Ubuntu 16.04). I found that commands were not being received fast enough, so stop commands were periodically issued, resulting in random stuttering/jerky movements.  The issue was fixed by increasing the time parameter, so the purpose of this PR is to add the speedj_time parameter to the parameter server so it can be easily adjusted (similar to the servoj_time parameter).


From the [UR scripting manual](http://www.sysaxes.com/manuels/scriptmanual_en_3.1.pdf): 
> **speedj** (qd, a, t_min)
> Joint speed
> Accelerate to and move with constant joint speed
> **Parameters**
> * qd: joint speeds [rad/s]
> * a: joint acceleration [rad/sˆ2] (of leading axis)
> * t_min: minimal time before function returns
